### PR TITLE
US-007: Crime scorer

### DIFF
--- a/agents/crime_scorer.py
+++ b/agents/crime_scorer.py
@@ -1,0 +1,129 @@
+import asyncio
+from datetime import date
+
+import httpx
+
+from tools.postcode import get_all_postcode_coordinates
+
+POLICE_API_BASE = "https://data.police.uk/api/crimes-street/all-crime"
+
+
+def _default_date() -> str:
+    """Return the most recent full month as YYYY-MM (current month minus 4)."""
+    today = date.today()
+    month = today.month - 4
+    year = today.year
+    if month <= 0:
+        month += 12
+        year -= 1
+    return f"{year}-{month:02d}"
+
+
+async def _fetch_crime_count(
+    client: httpx.AsyncClient, district: str, lat: float, lng: float, date_str: str
+) -> dict:
+    url = POLICE_API_BASE
+    params = {"lat": lat, "lng": lng, "date": date_str}
+    try:
+        response = await client.get(url, params=params, timeout=30.0)
+    except httpx.RequestError as exc:
+        raise RuntimeError(
+            f"Could not reach UK Police API: {exc}"
+        ) from exc
+
+    if response.status_code == 404 or response.text.strip() in ("", "[]"):
+        return {"district": district, "raw_count": 0}
+
+    response.raise_for_status()
+
+    data = response.json()
+    return {"district": district, "raw_count": len(data) if data else 0}
+
+
+def _normalise(results: list[dict]) -> list[dict]:
+    counts = [r["raw_count"] for r in results]
+    min_count = min(counts)
+    max_count = max(counts)
+
+    if max_count == min_count:
+        return [
+            {"district": r["district"], "raw_count": r["raw_count"], "score": 0.5}
+            for r in results
+        ]
+
+    return [
+        {
+            "district": r["district"],
+            "raw_count": r["raw_count"],
+            "score": round(1 - (r["raw_count"] - min_count) / (max_count - min_count), 6),
+        }
+        for r in results
+    ]
+
+
+async def score_all_postcodes(date: str | None = None) -> list[dict]:
+    """Fetch crime counts for all London postcode districts and return normalised safety scores.
+
+    Args:
+        date: Month to query in YYYY-MM format. Defaults to the most recent full month
+              (current month minus 2, to ensure data availability).
+
+    Returns:
+        List of dicts with keys: district, raw_count, score.
+        score is normalised 0-1 where 1 = safest (lowest crime count).
+
+    Raises:
+        RuntimeError: If the UK Police API is unreachable.
+    """
+    if date is None:
+        date = _default_date()
+
+    coordinates = await get_all_postcode_coordinates()
+
+    raw_results = []
+    async with httpx.AsyncClient() as client:
+        for i in range(0, len(coordinates), 5):
+            batch = coordinates[i : i + 5]
+            batch_results = await asyncio.gather(
+                *[
+                    _fetch_crime_count(client, coord["outcode"], coord["lat"], coord["lng"], date)
+                    for coord in batch
+                ]
+            )
+            raw_results.extend(batch_results)
+            if i + 5 < len(coordinates):
+                await asyncio.sleep(1)
+
+    return _normalise(raw_results)
+
+
+async def score_single_postcode(district: str, date: str | None = None) -> dict:
+    """Fetch the crime score for a single postcode district.
+
+    The score is computed relative to only this district (always 0.5 since there is
+    one data point), but raw_count reflects the true API value. Useful for testing
+    connectivity and response shape.
+
+    Args:
+        district: A postcode district string, e.g. "E1".
+        date: Month to query in YYYY-MM format. Defaults to the most recent full month.
+
+    Returns:
+        A dict with keys: district, raw_count, score.
+
+    Raises:
+        RuntimeError: If the UK Police API is unreachable.
+    """
+    if date is None:
+        date = _default_date()
+
+    from tools.postcode import get_postcode_coordinates
+
+    coord = await get_postcode_coordinates(district)
+
+    async with httpx.AsyncClient() as client:
+        result = await _fetch_crime_count(
+            client, district, coord["lat"], coord["lng"], date
+        )
+
+    return {"district": result["district"], "raw_count": result["raw_count"], "score": 0.5}

--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 # directions and zones. Mix of central (Z1), inner (Z2-3), outer (Z3-6).
 LONDON_POSTCODE_DISTRICTS = [
     # Central – Zone 1
-    "EC1", "WC1", "SW1", "W1",
+    "EC1A", "WC1A", "SW1A", "W1A",
     # Inner North
     "N1", "N4", "NW1", "NW3",
     # Inner East

--- a/tests/test_crime_scorer.py
+++ b/tests/test_crime_scorer.py
@@ -1,0 +1,28 @@
+import pytest
+
+from agents.crime_scorer import score_all_postcodes, score_single_postcode
+
+
+@pytest.mark.asyncio
+async def test_score_all_postcodes_returns_40_dicts():
+    results = await score_all_postcodes()
+    assert len(results) == 40
+
+
+@pytest.mark.asyncio
+async def test_all_scores_between_0_and_1():
+    results = await score_all_postcodes()
+    for entry in results:
+        assert 0.0 <= entry["score"] <= 1.0, (
+            f"Score out of range for {entry['district']}: {entry['score']}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_score_single_postcode_e1_shape():
+    result = await score_single_postcode("E1")
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"district", "raw_count", "score"}
+    assert result["district"] == "E1"
+    assert isinstance(result["raw_count"], int)
+    assert isinstance(result["score"], float)


### PR DESCRIPTION
Closes #7. Async crime scorer using UK Police API. Returns normalised 0-1 safety score across all 40 London postcode districts using batched concurrent API calls.