### PR TITLE
US-008: Green space scorer

### DIFF
--- a/agents/green_scorer.py
+++ b/agents/green_scorer.py
@@ -1,0 +1,143 @@
+import asyncio
+
+import httpx
+
+from tools.postcode import get_all_postcode_coordinates, get_postcode_coordinates
+
+OVERPASS_API = "https://overpass-api.de/api/interpreter"
+
+_OVERPASS_QUERY_TEMPLATE = """
+[out:json];
+(
+  node["leisure"="park"](around:800,{lat},{lng});
+  way["leisure"="park"](around:800,{lat},{lng});
+  relation["leisure"="park"](around:800,{lat},{lng});
+  node["leisure"="nature_reserve"](around:800,{lat},{lng});
+  way["leisure"="nature_reserve"](around:800,{lat},{lng});
+  relation["leisure"="nature_reserve"](around:800,{lat},{lng});
+  node["landuse"="grass"](around:800,{lat},{lng});
+  way["landuse"="grass"](around:800,{lat},{lng});
+  relation["landuse"="grass"](around:800,{lat},{lng});
+  node["landuse"="forest"](around:800,{lat},{lng});
+  way["landuse"="forest"](around:800,{lat},{lng});
+  relation["landuse"="forest"](around:800,{lat},{lng});
+);
+out count;
+"""
+
+
+_RETRY_STATUSES = {429, 504}
+_MAX_RETRIES = 3
+_RETRY_DELAYS = [10, 20, 30]
+
+
+async def _fetch_green_count(
+    client: httpx.AsyncClient, district: str, lat: float, lng: float
+) -> dict:
+    query = _OVERPASS_QUERY_TEMPLATE.format(lat=lat, lng=lng)
+
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            response = await client.post(
+                OVERPASS_API, data={"data": query}, timeout=30.0
+            )
+        except httpx.RequestError as exc:
+            raise RuntimeError(
+                f"Could not reach Overpass API: {exc}"
+            ) from exc
+
+        if response.status_code in _RETRY_STATUSES:
+            if attempt < _MAX_RETRIES:
+                await asyncio.sleep(_RETRY_DELAYS[attempt])
+                continue
+            raise RuntimeError(
+                f"Overpass API is rate limiting or unavailable for district {district} "
+                f"(HTTP {response.status_code}) after {_MAX_RETRIES} retries."
+            )
+
+        response.raise_for_status()
+
+        data = response.json()
+        elements = data.get("elements", [])
+        if not elements:
+            return {"district": district, "raw_count": 0}
+
+        count_element = elements[0]
+        total = int(count_element.get("tags", {}).get("total", 0))
+        return {"district": district, "raw_count": total}
+
+    raise RuntimeError(f"Overpass API failed for district {district} after {_MAX_RETRIES} retries.")
+
+
+def _normalise(results: list) -> list:
+    counts = [r["raw_count"] for r in results]
+    min_count = min(counts)
+    max_count = max(counts)
+
+    if max_count == min_count:
+        return [
+            {"district": r["district"], "raw_count": r["raw_count"], "score": 0.5}
+            for r in results
+        ]
+
+    return [
+        {
+            "district": r["district"],
+            "raw_count": r["raw_count"],
+            "score": round((r["raw_count"] - min_count) / (max_count - min_count), 6),
+        }
+        for r in results
+    ]
+
+
+async def score_all_postcodes() -> list:
+    """Fetch green space counts for all London postcode districts and return normalised scores.
+
+    Returns:
+        List of dicts with keys: district, raw_count, score.
+        score is normalised 0-1 where 1 = most green space.
+
+    Raises:
+        RuntimeError: If the Overpass API is unreachable.
+    """
+    coordinates = await get_all_postcode_coordinates()
+
+    raw_results = []
+    async with httpx.AsyncClient() as client:
+        for i in range(0, len(coordinates), 2):
+            batch = coordinates[i : i + 2]
+            batch_results = await asyncio.gather(
+                *[
+                    _fetch_green_count(client, coord["outcode"], coord["lat"], coord["lng"])
+                    for coord in batch
+                ]
+            )
+            raw_results.extend(batch_results)
+            if i + 2 < len(coordinates):
+                await asyncio.sleep(5)
+
+    return _normalise(raw_results)
+
+
+async def score_single_postcode(district: str) -> dict:
+    """Fetch the green space count for a single postcode district.
+
+    The score is a placeholder of 0.5 since normalisation requires all districts.
+
+    Args:
+        district: A postcode district string, e.g. "E1".
+
+    Returns:
+        A dict with keys: district, raw_count, score.
+
+    Raises:
+        RuntimeError: If the Overpass API is unreachable.
+    """
+    coord = await get_postcode_coordinates(district)
+
+    async with httpx.AsyncClient() as client:
+        result = await _fetch_green_count(
+            client, district, coord["lat"], coord["lng"]
+        )
+
+    return {"district": result["district"], "raw_count": result["raw_count"], "score": 0.5}

--- a/tests/test_green_scorer.py
+++ b/tests/test_green_scorer.py
@@ -1,0 +1,28 @@
+import pytest
+
+from agents.green_scorer import score_all_postcodes, score_single_postcode
+
+
+@pytest.mark.asyncio
+async def test_score_all_postcodes_returns_40_dicts():
+    results = await score_all_postcodes()
+    assert len(results) == 40
+
+
+@pytest.mark.asyncio
+async def test_all_scores_between_0_and_1():
+    results = await score_all_postcodes()
+    for entry in results:
+        assert 0.0 <= entry["score"] <= 1.0, (
+            f"Score out of range for {entry['district']}: {entry['score']}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_score_single_postcode_e1_shape():
+    result = await score_single_postcode("E1")
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"district", "raw_count", "score"}
+    assert result["district"] == "E1"
+    assert isinstance(result["raw_count"], int)
+    assert isinstance(result["score"], float)


### PR DESCRIPTION
Closes #8. Async green space scorer using Overpass API. Counts parks, nature reserves, grass and forest within 800m of each postcode centroid. Returns normalised 0-1 score across all 40 districts.