### PR TITLE
US-042b: Monthly refresh cron — Vercel cron schedule

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/refresh-scores",
+      "schedule": "0 0 1 * *"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #55

Adds vercel.json with cron schedule pointing at /api/cron/refresh-scores.
Fires at midnight on the first of every month.

Endpoint implementation tracked in US-018 (FastAPI scaffold, Milestone 3).